### PR TITLE
修改了 print 和 simplify

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -234,57 +234,34 @@ void poly::input(string a) {
   simplify();
 }
 
-void printp(Node n) {
-  if (n.coefficient > 0) {
-    if (n.coefficient == 1 && n.degree != 1) {
-      cout << "+x^" << n.degree;
-    } else if (n.coefficient == 1 && n.degree == 1) {
-      cout << "+x";
-    } else if (n.coefficient != 1 && n.degree == 1) {
-      cout << "+" << n.coefficient << "x";
-    } else if (n.coefficient != 1 && n.degree != 1)
-      cout << "+" << n.coefficient << "x^" << n.degree;
-    else if (n.degree == 0) {
-      cout << "+" << n.coefficient;
-    }
-  }
-
-  if (n.coefficient == 0)
-    return;
-  if (n.coefficient < 0) {
-    if (n.degree > 1) {
-      cout << n.coefficient << "x^" << n.degree;
-    } else if (n.coefficient != -1 && n.degree == 1) {
-      cout << n.coefficient << "x";
-    } else if (n.coefficient == -1 && n.degree == 1) {
-      cout << "-x";
-    } else if (n.degree == 0) {
-      cout << n.coefficient;
-    }
-  };
-}
-
 void poly::print() {
   list<Node>::iterator it = L.begin();
-  for (; it != L.end(); ++it) {
+  bool first = true;
+
+  for (list<Node>::iterator it = L.begin(); it != L.end();
+       ++it, first = false) {
     Node &n = *it;
+    bool positive = n.coefficient > 0;
+    double number = fabs(n.coefficient);
+    bool isOne = number == 1;
 
-    if (it == L.begin()) {
-      if (n.coefficient == 1 && n.degree != 1) {
-        cout << "x^" << n.degree;
-      } else if (n.coefficient == 1 && n.degree == 1) {
-        cout << "x";
-      } else if (n.coefficient != 1 && n.degree == 1) {
-        cout << n.coefficient << "x";
-      } else if (n.coefficient != 1 && n.degree != 1)
-        cout << n.coefficient << "x^" << n.degree;
-      else if (n.degree == 0) {
-        cout << n.coefficient;
-      }
+    if (!positive)
+      cout << '-';
+    else if (!first)
+      cout << '+';
 
-    } else
-      printp(n);
+    if (n.degree == 0 || !isOne)
+      cout << n.coefficient;
+
+    if (n.degree != 0) {
+      cout << 'x';
+    }
+
+    if (n.degree > 1) {
+      cout << '^' << n.degree;
+    }
   }
+
   cout << endl;
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <list>
 #include <sstream>

--- a/main.cpp
+++ b/main.cpp
@@ -19,14 +19,13 @@ Node::Node(float a, int b) {
 }
 
 class poly {
- private:
+private:
   list<Node> L;
 
- public:
+public:
   void input(string a);
   void print();
   void simplify();
-  
 
   poly operator+(poly &as);
   poly operator*(poly &as);
@@ -34,67 +33,54 @@ class poly {
   poly operator/(poly &as);
 };
 
-
-
 poly poly::operator+(poly &as) {
   list<Node>::iterator it1 = L.begin();
   list<Node>::iterator it2 = as.L.begin();
-  
+
   poly poly3;
   for (; it2 != as.L.end();) {
-    
+
     Node &n1 = *it1;
     Node &n2 = *it2;
-    if (n2.degree < n1.degree)
-    {
-    	poly3.L.push_back(Node(n1.coefficient,n1.degree));
-    	++it1;
-	}
-      
-    else if (n1.degree < n2.degree)
-    {
-    	poly3.L.push_back(Node(n2.coefficient,n2.degree));
-    	++it2;
-	}
-      
-    else if (n1.degree == n2.degree) 
-	{
-    	poly3.L.push_back(Node((n2.coefficient+n1.coefficient),n1.degree));
-    	++it1;
-    	++it2;
+    if (n2.degree < n1.degree) {
+      poly3.L.push_back(Node(n1.coefficient, n1.degree));
+      ++it1;
     }
-    
-  }
-  
-    for(;it1!=L.end();)
-    {
-    	Node &n1 = *it1;
-    	Node &n2 = *it2;
-    	if(n1.degree==n2.degree)
-    	{
-    		poly3.L.push_back(Node((n2.coefficient+n1.coefficient),n1.degree));
-		}
-		else if(n1.degree!=n2.degree)
-		{
-			poly3.L.push_back(Node(n1.coefficient,n1.degree));
-			++it1;
-		}
-	}
- 
- 	Node &n1 = *it1;
-    Node &n2 = *it2;
-    if(n1.degree==n2.degree)
-    {
-    	poly3.L.push_back(Node((n2.coefficient+n1.coefficient),n1.degree));
-	}
-	else if(n1.degree!=n2.degree)
-	{
-		poly3.L.push_back(Node(n1.coefficient,n1.degree));
-		poly3.L.push_back(Node(n2.coefficient,n2.degree));
-	}
 
-	poly3.simplify();
-  	return poly3;
+    else if (n1.degree < n2.degree) {
+      poly3.L.push_back(Node(n2.coefficient, n2.degree));
+      ++it2;
+    }
+
+    else if (n1.degree == n2.degree) {
+      poly3.L.push_back(Node((n2.coefficient + n1.coefficient), n1.degree));
+      ++it1;
+      ++it2;
+    }
+  }
+
+  for (; it1 != L.end();) {
+    Node &n1 = *it1;
+    Node &n2 = *it2;
+    if (n1.degree == n2.degree) {
+      poly3.L.push_back(Node((n2.coefficient + n1.coefficient), n1.degree));
+    } else if (n1.degree != n2.degree) {
+      poly3.L.push_back(Node(n1.coefficient, n1.degree));
+      ++it1;
+    }
+  }
+
+  Node &n1 = *it1;
+  Node &n2 = *it2;
+  if (n1.degree == n2.degree) {
+    poly3.L.push_back(Node((n2.coefficient + n1.coefficient), n1.degree));
+  } else if (n1.degree != n2.degree) {
+    poly3.L.push_back(Node(n1.coefficient, n1.degree));
+    poly3.L.push_back(Node(n2.coefficient, n2.degree));
+  }
+
+  poly3.simplify();
+  return poly3;
 }
 
 poly poly::operator*(poly &as) {
@@ -105,7 +91,8 @@ poly poly::operator*(poly &as) {
     Node &n1 = *it1;
     for (; it2 != as.L.end(); ++it2) {
       Node &n2 = *it2;
-      result.L.push_back(Node(n1.coefficient*n2.coefficient, n1.degree + n2.degree));
+      result.L.push_back(
+          Node(n1.coefficient * n2.coefficient, n1.degree + n2.degree));
     }
   }
 
@@ -116,33 +103,28 @@ poly poly::operator*(poly &as) {
 poly poly::operator-(poly &as) {
   list<Node>::iterator it1 = L.begin();
   list<Node>::iterator it2 = as.L.begin();
-  
+
   poly poly3;
   for (; it2 != as.L.end();) {
-    
+
     Node &n1 = *it1;
     Node &n2 = *it2;
-    if (n2.degree < n1.degree)
-    {
-    	poly3.L.push_back(Node(n1.coefficient,n1.degree));
-    	++it1;
-	}
-      
-    else if (n1.degree < n2.degree)
-    {
-    	poly3.L.push_back(Node(n2.coefficient,n2.degree));
-    	++it2;
-	}
-      
-    else if (n1.degree == n2.degree) 
-	{
-    	poly3.L.push_back(Node((n2.coefficient-n1.coefficient),n1.degree));
-    	++it1;
-    	++it2;
+    if (n2.degree < n1.degree) {
+      poly3.L.push_back(Node(n1.coefficient, n1.degree));
+      ++it1;
     }
-    
+
+    else if (n1.degree < n2.degree) {
+      poly3.L.push_back(Node(n2.coefficient, n2.degree));
+      ++it2;
+    }
+
+    else if (n1.degree == n2.degree) {
+      poly3.L.push_back(Node((n2.coefficient - n1.coefficient), n1.degree));
+      ++it1;
+      ++it2;
+    }
   }
- 
 
   return poly3;
 }
@@ -159,139 +141,125 @@ void poly::input(string a) {
 
   while (!stop_flag) {
     switch (current_state) {
-      case FAIL:
+    case FAIL:
+      stop_flag = true;
+      break;
+    case STORE: {
+      if (neg == true)
+        cof = -cof;
+      L.push_back(Node(cof, deg));
+      deg = 0;
+      cof = 0;
+      neg = false;
+      flag_no_cof = false;
+      flag_need_sign = true;
+      current_state = ET_PM;
+      break;
+    }
+    case ET_PM: {
+      if (s.eof()) {
         stop_flag = true;
         break;
-      case STORE: {
-        if (neg == true) cof = -cof;
-        L.push_back(Node(cof, deg));
-        deg = 0;
-        cof = 0;
-        neg = false;
-        flag_no_cof = false;
-        flag_need_sign = true;
-        current_state = ET_PM;
-        break;
-      }
-      case ET_PM: {
-        if (s.eof()) {
-          stop_flag = true;
-          break;
-        }
-
-        char ch = s.peek();
-        if (flag_need_sign) {
-          if (ch == '+' || ch == '-') {
-            neg = ch == '-';
-            s.get();
-            current_state = ET_COEFFICIENT;
-          } else {
-            current_state = FAIL;
-          }
-        } else
-          current_state = ET_COEFFICIENT;
-        break;
       }
 
-      case ET_COEFFICIENT: {
-        double co;
-        s >> co;
-        if (!s.fail())
-          cof = co;
-        else {
-          flag_no_cof = true;
-          cof = 1.0;
-        }
-        s.clear();
-        current_state = ET_X;
-        break;
-      }
-
-      case ET_X: {
-        if (s.peek() == 'x') {
-          current_state = ET_CARET;
+      char ch = s.peek();
+      if (flag_need_sign) {
+        if (ch == '+' || ch == '-') {
+          neg = ch == '-';
           s.get();
-          break;
-        } else if (s.peek() != 'x' && flag_no_cof == true) {
+          current_state = ET_COEFFICIENT;
+        } else {
           current_state = FAIL;
-          break;
-        } else if (s.peek() != 'x' && flag_no_cof == false)
-          deg = 0;
+        }
+      } else
+        current_state = ET_COEFFICIENT;
+      break;
+    }
+
+    case ET_COEFFICIENT: {
+      double co;
+      s >> co;
+      if (!s.fail())
+        cof = co;
+      else {
+        flag_no_cof = true;
+        cof = 1.0;
+      }
+      s.clear();
+      current_state = ET_X;
+      break;
+    }
+
+    case ET_X: {
+      if (s.peek() == 'x') {
+        current_state = ET_CARET;
+        s.get();
+        break;
+      } else if (s.peek() != 'x' && flag_no_cof == true) {
+        current_state = FAIL;
+        break;
+      } else if (s.peek() != 'x' && flag_no_cof == false)
+        deg = 0;
+      current_state = STORE;
+      break;
+    }
+    case ET_CARET: {
+      if (s.peek() == '^') {
+        current_state = ET_DEGREE;
+        s.get();
+        break;
+      } else if (s.peek() != '^') {
+        deg = 1;
         current_state = STORE;
         break;
-      }
-      case ET_CARET: {
-        if (s.peek() == '^') {
-          current_state = ET_DEGREE;
-          s.get();
-          break;
-        } else if (s.peek() != '^') {
-          deg = 1;
-          current_state = STORE;
-          break;
-        } else
-          current_state = FAIL;
-        break;
-      }
-      case ET_DEGREE: {
-        int de;
-        s >> de;
-        if (!s.fail() && de > 0) {
-          deg = de;
-          current_state = STORE;
-        } else
-          current_state = FAIL;
-        s.clear();
-        break;
-      }
+      } else
+        current_state = FAIL;
+      break;
+    }
+    case ET_DEGREE: {
+      int de;
+      s >> de;
+      if (!s.fail() && de > 0) {
+        deg = de;
+        current_state = STORE;
+      } else
+        current_state = FAIL;
+      s.clear();
+      break;
+    }
     }
   }
 
   simplify();
 }
 
-void printp(Node n) {//感觉打印这里的函数真是写得啰啰嗦嗦的 
-  if (n.coefficient > 0) 
-  {
-  	if(n.coefficient==1&&n.degree!=1)
-    	{
-    		cout <<  "+x^" << n.degree;
-		}
-		else if(n.coefficient==1&&n.degree==1)
-		{
-			cout<<"+x";
-		}
-		else if(n.coefficient!=1&&n.degree==1)
-		{
-			cout<<"+"<<n.coefficient<<"x";
-		}
-		else if(n.coefficient!=1&&n.degree!=1)
-      		cout <<"+"<< n.coefficient << "x^" << n.degree;
-      	else if(n.degree==0)
-      	{
-      		cout<<"+"<<n.coefficient;
-		}
+void printp(Node n) {
+  if (n.coefficient > 0) {
+    if (n.coefficient == 1 && n.degree != 1) {
+      cout << "+x^" << n.degree;
+    } else if (n.coefficient == 1 && n.degree == 1) {
+      cout << "+x";
+    } else if (n.coefficient != 1 && n.degree == 1) {
+      cout << "+" << n.coefficient << "x";
+    } else if (n.coefficient != 1 && n.degree != 1)
+      cout << "+" << n.coefficient << "x^" << n.degree;
+    else if (n.degree == 0) {
+      cout << "+" << n.coefficient;
+    }
   }
 
-  if (n.coefficient == 0) return;
-  if (n.coefficient < 0) 
-  {
-  	if(n.degree>1)
-  	{
-  		cout << n.coefficient << "x^" << n.degree;
-	}
-	else if(n.coefficient!=-1&&n.degree==1)
-	{
-		cout<<n.coefficient<<"x";
-	}
-	else if(n.coefficient==-1&&n.degree==1)
-	{
-		cout<<"-x";
-	}
-	else if(n.degree==0)
-	{
-		cout<<n.coefficient;
-	}
+  if (n.coefficient == 0)
+    return;
+  if (n.coefficient < 0) {
+    if (n.degree > 1) {
+      cout << n.coefficient << "x^" << n.degree;
+    } else if (n.coefficient != -1 && n.degree == 1) {
+      cout << n.coefficient << "x";
+    } else if (n.coefficient == -1 && n.degree == 1) {
+      cout << "-x";
+    } else if (n.degree == 0) {
+      cout << n.coefficient;
+    }
   };
 }
 
@@ -301,25 +269,18 @@ void poly::print() {
     Node &n = *it;
 
     if (it == L.begin()) {
-    	if(n.coefficient==1&&n.degree!=1)
-    	{
-    		cout <<  "x^" << n.degree;
-		}
-		else if(n.coefficient==1&&n.degree==1)
-		{
-			cout<<"x";
-		}
-		else if(n.coefficient!=1&&n.degree==1)
-		{
-			cout<<n.coefficient<<"x";
-		}
-		else if(n.coefficient!=1&&n.degree!=1)
-      		cout << n.coefficient << "x^" << n.degree;
-      	else if(n.degree==0)
-      	{
-      		cout<<n.coefficient;
-		}
-      	
+      if (n.coefficient == 1 && n.degree != 1) {
+        cout << "x^" << n.degree;
+      } else if (n.coefficient == 1 && n.degree == 1) {
+        cout << "x";
+      } else if (n.coefficient != 1 && n.degree == 1) {
+        cout << n.coefficient << "x";
+      } else if (n.coefficient != 1 && n.degree != 1)
+        cout << n.coefficient << "x^" << n.degree;
+      else if (n.degree == 0) {
+        cout << n.coefficient;
+      }
+
     } else
       printp(n);
   }
@@ -354,11 +315,11 @@ int main(int argc, char **argv) {
   poly1.print();
   cout << "Please type in another polynomial:";
   string x;
-  cin>> x;
-  poly poly2,poly3;
+  cin >> x;
+  poly poly2, poly3;
   poly2.input(x);
   poly2.print();
-  poly3 = poly2+poly1;
+  poly3 = poly2 + poly1;
   poly3.print();
 
   return 0;

--- a/main.cpp
+++ b/main.cpp
@@ -274,7 +274,12 @@ void poly::simplify() {
 
   for (list<Node>::iterator it = L.begin(); it != L.end(); ++it) {
     Node &n = *it;
-    Node &m = *std::next(it, 1);
+    auto nextIt = std::next(it, 1);
+
+    if (nextIt == L.end()) break;
+
+    Node &m = *nextIt;
+
     if (m.degree == n.degree) {
       n.coefficient += m.coefficient;
       it = L.erase(it);

--- a/main.cpp
+++ b/main.cpp
@@ -285,6 +285,10 @@ void poly::simplify() {
       it = L.erase(it);
     }
   }
+
+  L.remove_if([](Node& n) {
+    return n.coefficient == 0;
+  });
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
## 更改
 + 用更清晰的思路写 `print`
 + 修正了 `simplify` 中的一些 bug

之前出现的 __无法输出常数项__ 的问题其实不是出在`print`上而是在`simplify`上。
设有多项式 `x^2+1`。执行完 `L.sort` 后 `L` 变为：

```
Node(1, 2) -> Node(1, 0)
```

当循环到最后一项时：

```
Node(1, 2) -> Node(1, 0) -> ???
                      ^      ^
                      n      m
```

此时 `m` 指向一个越界的区域，其值未定义（很多时候是 `0`），从而导致常数项与`m`合并而被删掉，从而输出时没有常数项╮(╯_╰)╭

对 `m` 执行越界检查可以解决这个问题

另外，在合并同类项后，应该剔除系数是 0 的项。